### PR TITLE
Add hub paper citation

### DIFF
--- a/papers.Rmd
+++ b/papers.Rmd
@@ -14,9 +14,22 @@ knitr::opts_chunk$set(echo = FALSE, message = FALSE, warning = FALSE)
 bibfile <- "papers.bib"
 ```
 
-To cite the European COVID-19 Forecast Hub, please use:
+To cite the European Covid-19 Forecast Hub in project in publications, please use the following references:
 
-[Sherratt, Katharine, et al. "Predictive performance of multi-model ensemble forecasts of COVID-19 across European nations." medRxiv (2022).](https://www.medrxiv.org/content/10.1101/2022.06.16.22276024)
+_Methodology and evaluation_
+
+> Sherratt, K., Gruson, H., Johnson, H., Niehus, R., Prasse, B., Sandman, F., ... & Funk, S. (2022). Predictive performance of multi-model ensemble forecasts of COVID-19 across European nations. _medRxiv_. DOI: https://doi.org/10.1101/2022.06.16.22276024
+
+_Data_
+
+> Katharine Sherratt, Hugo Gruson, Helen Johnson, Rene Niehus, Bastian
+> Prasse, Frank Sandman, Jannik Deuschel, Daniel Wolffram, Sam Abbott,
+> Alexander Ullrich, Graham Gibson, Evan L Ray, Nicholas G Reich, Daniel
+> Sheldon, Yijin Wang, Nutcha Wattanachit, Lijing Wang, Jan Trnka,
+> Guillaume Obozinski, … Sebastian Funk. (2022). European Covid-19
+> Forecast Hub (v2022.10.20) \[Data set\]. Zenodo.
+> <https://doi.org/10.5281/zenodo.7229300>
+
 
 Please [get in touch](contact.html) if you know or published an article using
 data from the European Covid-19 Forecast Hub or mentioning it as a public health

--- a/papers.Rmd
+++ b/papers.Rmd
@@ -14,6 +14,10 @@ knitr::opts_chunk$set(echo = FALSE, message = FALSE, warning = FALSE)
 bibfile <- "papers.bib"
 ```
 
+To cite the European COVID-19 Forecast Hub, please use:
+
+[Sherratt, Katharine, et al. "Predictive performance of multi-model ensemble forecasts of COVID-19 across European nations." medRxiv (2022).](https://www.medrxiv.org/content/10.1101/2022.06.16.22276024)
+
 Please [get in touch](contact.html) if you know or published an article using
 data from the European Covid-19 Forecast Hub or mentioning it as a public health
 tool.


### PR DESCRIPTION
A couple of times recently I've seen the hub cited by reference to Zenodo. This can be difficult to reference correctly in a way that points back to the Hub (e.g. [this recent paper (Kulah et al)](https://www.sciencedirect.com/science/article/pii/S0957417422020528#bb29) where the ref goes to a dead link). The full Hub paper gives the proper methodology so makes sense to include it as the suggested citation.

Separately, added issue #49 to update the list of papers on this page at some point.